### PR TITLE
peer-programmed modifications for python3.9

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,12 +99,14 @@ def main():
         system("docker-compose exec contact-watcher-db sh -c \"psql -U vdbm -d vulcanize_public -c \\\"INSERT INTO "
                "contract.events(name) VALUES ('MessageChanged') ON CONFLICT DO NOTHING;\\\"\"")
         # contract
-        fp = tempfile.NamedTemporaryFile(suffix='.sql')
-        fp.write(b"INSERT INTO contract.contracts (name, address, abi, events, starting_block) VALUES ('" +
-                 str.encode(contract) + b"', '" + str.encode(contract_address) + b"', '" +
-                 str.encode(abi) + b"', '{1}', 1);")
+        f = open("a.sql", "w")
+        f.write(str("INSERT INTO contract.contracts (name, address, abi, events, starting_block) VALUES ('" +
+                 contract + "', '" + contract_address + "', '" +
+                 abi + "', '{1}', 1);"))
+        f.close()
+        system(f'cat {f.name}')
         system(
-            f'docker cp "{fp.name}" $(docker-compose ps -q contact-watcher-db):/tmp/contract.sql')
+            f'docker cp "{f.name}" $(docker-compose ps -q contact-watcher-db):/tmp/contract.sql')
         system(
             "docker-compose exec contact-watcher-db sh -c \"psql -U vdbm -d vulcanize_public < /tmp/contract.sql\"")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pkg-resources==0.0.0
 toml==0.10.1


### PR DESCRIPTION
These modifications don't completely work, as results have not been inserted into the auto-generated table.

environment details:
OS: arch linux x86_64
python version: 3.9.1

In order to access 3.9 on ubuntu, I recommend using the deadsnakes ppa